### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/ingenieroberrocal/6c939cfb-9c6a-4a09-8de8-96d65b7f6e5d/e0b739ef-3c95-479c-a232-f868825267b9/_apis/work/boardbadge/4413be69-ba6b-422c-9b6a-0e5e35a0c80c)](https://dev.azure.com/ingenieroberrocal/6c939cfb-9c6a-4a09-8de8-96d65b7f6e5d/_boards/board/t/e0b739ef-3c95-479c-a232-f868825267b9/Microsoft.RequirementCategory)
 # don-kbo
 PWA Kubo
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ingenieroberrocal/6c939cfb-9c6a-4a09-8de8-96d65b7f6e5d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.